### PR TITLE
Removed SF event name workarounds

### DIFF
--- a/src/EventBand/Adapter/Symfony/AdapterEventListener.php
+++ b/src/EventBand/Adapter/Symfony/AdapterEventListener.php
@@ -33,7 +33,7 @@ class AdapterEventListener
         } elseif ($symfonyEvent instanceof SymfonyEventWrapper) {
             $event = $symfonyEvent->getWrappedEvent();
         } else {
-            $event = new EventWrapper($symfonyEvent);
+            $event = new EventWrapper($symfonyEvent, $this->subscription->getEventName());
         }
 
         if (!$this->subscription->dispatch($event, $this->dispatcher)) {

--- a/src/EventBand/Adapter/Symfony/BandEventDispatcher.php
+++ b/src/EventBand/Adapter/Symfony/BandEventDispatcher.php
@@ -53,6 +53,9 @@ class BandEventDispatcher implements EventDispatcherInterface, BandDispatcher
         if ($event === null) {
             $event = new SerializableSymfonyEvent();
         }
+        if (method_exists($event, 'setName')) {
+            $event->setName($eventName);
+        }
 
         return $this->dispatcher->dispatch($eventName, $event);
     }

--- a/src/EventBand/Adapter/Symfony/EventWrapper.php
+++ b/src/EventBand/Adapter/Symfony/EventWrapper.php
@@ -16,10 +16,18 @@ use Symfony\Component\EventDispatcher\Event as SymfonyEvent;
 class EventWrapper implements Event
 {
     private $symfonyEvent;
+    private $name;
 
-    public function __construct(SymfonyEvent $symfonyEvent)
+    /**
+     * Wrap symfony event
+     *
+     * @param SymfonyEvent  $symfonyEvent
+     * @param string|null   $name
+     */
+    public function __construct(SymfonyEvent $symfonyEvent, $name = null)
     {
         $this->symfonyEvent = $symfonyEvent;
+        $this->name = $name;
     }
 
     /**
@@ -27,6 +35,6 @@ class EventWrapper implements Event
      */
     public function getName()
     {
-        return $this->symfonyEvent->getName();
+        return $this->name !== null ? $this->name : $this->symfonyEvent->getName();
     }
 }

--- a/tests/EventBand/Adapter/Symfony/Tests/AdapterEventListenerTest.php
+++ b/tests/EventBand/Adapter/Symfony/Tests/AdapterEventListenerTest.php
@@ -5,8 +5,10 @@
 
 namespace EventBand\Adapter\Symfony\Tests;
 
+use EventBand\Adapter\Symfony\EventWrapper;
 use EventBand\Adapter\Symfony\SymfonyEventWrapper;
 use EventBand\Adapter\Symfony\AdapterEventListener;
+use EventBand\Event;
 use PHPUnit_Framework_TestCase as TestCase;
 
 /**
@@ -17,15 +19,15 @@ use PHPUnit_Framework_TestCase as TestCase;
 class AdapterEventListenerTest extends TestCase
 {
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject
+     * @var \PHPUnit_Framework_MockObject_MockObject|\EventBand\BandDispatcher
      */
     private $dispatcher;
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject
+     * @var \PHPUnit_Framework_MockObject_MockObject|\EventBand\Subscription
      */
     private $subscription;
     /**
-     * @var \PHPUnit_Framework_MockObject_MockObject
+     * @var \PHPUnit_Framework_MockObject_MockObject|\EventBand\Event
      */
     private $event;
     /**
@@ -81,5 +83,30 @@ class AdapterEventListenerTest extends TestCase
 
         call_user_func($this->listener, $wrapper);
         $this->assertTrue($wrapper->isPropagationStopped());
+    }
+
+    /**
+     * @test event name is passed with wrapped event
+     */
+    public function symfonyEventName()
+    {
+        $symfonyEvent = $this->getMock('Symfony\Component\EventDispatcher\Event');
+
+        $eventName = 'event_name';
+        $this->subscription
+            ->expects($this->any())
+            ->method('getEventName')
+            ->will($this->returnValue($eventName));
+
+        $this->subscription
+            ->expects($this->once())
+            ->method('dispatch')
+            ->with($this->callback(function (Event $e) use ($eventName) {
+                return $e->getName() == $eventName;
+            }))
+            ->will($this->returnValue(true))
+        ;
+
+        call_user_func($this->listener, $symfonyEvent);
     }
 }


### PR DESCRIPTION
I made some hacks for symfony adapter to support SF 3.0. Please review and test
